### PR TITLE
The phrases to create a database have a new 'find or' part

### DIFF
--- a/features/steps/database_mgmt.py
+++ b/features/steps/database_mgmt.py
@@ -1,4 +1,6 @@
+import openerp
 from support import *
+
 
 @given('the server is up and running OpenERP {version}')
 def impl(ctx, version):
@@ -25,19 +27,73 @@ def impl(ctx, user, password):
     # set_trace()
     # assert_true(0)
 
-@given(u'I create database "{db_name}" with admin password "{admin_pass}"')
-def impl(ctx, db_name, admin_pass):
-    ctx.client.create_database(admin_pass, db_name)
 
-@given(u'I create database "{db_name}"')
-def impl(ctx, db_name):
+def _create_database(ctx, admin_passwd, db_name, demo=False,
+                     raise_if_exists=True):
+    try:
+        ctx.client.create_database(admin_passwd, db_name, demo=demo)
+    except openerp.service.db.DatabaseExists:
+        if raise_if_exists:
+            raise
+        else:
+            puts("Database %s already exists" % db_name)
+
+
+@given(u'I{find_or}create database "{db_name}" with admin password "{admin_pass}"')
+def impl(ctx, find_or, db_name, admin_pass):
+    """Create database using the given name and a custom admin password.
+
+    The phrase::
+
+        I create database "xxx" with admin password "abc"
+
+    will raise an error if the database xxx already exists, while::
+
+        I find or create database "xxx" with admin password "abc"
+
+    will skip the creation if it already exists.
+    """
+    raise_if_exists = find_or.strip() != 'find or'
+    _create_database(ctx, admin_pass, db_name, raise_if_exists=raise_if_exists)
+
+
+@given(u'I{find_or}create database "{db_name}"')
+def impl(ctx, db_name, find_or):
+    """Create database using the given name.
+
+    The admin password is read from the config file.
+
+    The phrase::
+
+        I create database "xxx"
+
+    will raise an error if the database xxx already exists, while::
+
+        I find or create database "xxx"
+
+    will skip the creation if it already exists.
+    """
     admin_passwd = ctx.conf.get('admin_passwd')
     assert admin_passwd
-    ctx.client.create_database(admin_passwd, db_name)
+    raise_if_exists = find_or.strip() != 'find or'
+    _create_database(ctx, admin_passwd, db_name,
+                     raise_if_exists=raise_if_exists)
 
-@given(u'I create database from config file')
-def impl(ctx):
-    "Create database from config file etc/openerp.cfg"
+
+@given(u'I{find_or}create database from config file')
+def impl(ctx, find_or):
+    """Create database from config file etc/openerp.cfg
+
+    The phrase::
+
+        I create database from config file
+
+    will raise an error if the database already exists, while::
+
+        I find or create database from config file
+
+    will skip the creation if it already exists.
+    """
     db_name = ctx.conf.get('db_name')
     admin_passwd = ctx.conf.get('admin_passwd')
     assert admin_passwd
@@ -45,4 +101,6 @@ def impl(ctx):
     demo = False
     if not ctx.conf['openerp_config'].get('without_demo'):
         demo = True
-    ctx.client.create_database(admin_passwd, db_name, demo=demo)
+    raise_if_exists = find_or.strip() != 'find or'
+    _create_database(ctx, admin_passwd, db_name, demo=demo,
+                     raise_if_exists=raise_if_exists)


### PR DESCRIPTION
which allow them to not raise an error if the database already
exists.

This is useful when a setup script is run several times on the same
database and we don't want to have a failure just because the database
already exist.
