### PR TITLE
Add missing import

### DIFF
--- a/features/steps/dsl.py
+++ b/features/steps/dsl.py
@@ -1,5 +1,6 @@
 from ast import literal_eval
 import time
+import erppeek
 from support.tools import puts, set_trace, model, assert_true, assert_equal
 from dsl_helpers import (parse_domain,
                          build_search_domain,


### PR DESCRIPTION
erppeek is used in the module:

```
File "/home/travis/build/camptocamp/predige_openerp/Scenario/OERPScenario/features/steps/dsl.py", line 59, in impl
ctx.found_items = erppeek.RecordList(Model, [])
NameError: global name 'erppeek' is not defined
```
