### PR TITLE
Check the result of Model.load()

### DIFF
--- a/features/steps/tools.py
+++ b/features/steps/tools.py
@@ -53,7 +53,12 @@ def impl(ctx, model_name, csvfile, sep=","):
     head = data.next()
     # generator does not work
     values = [x for x in data]
-    model(model_name).load(head, values)
+    result = model(model_name).load(head, values)
+    if not result['ids']:
+        messages = '\n'.join('- %s' % msg for msg in result['messages'])
+        raise Exception("Failed to load file '%s' "
+                        "in '%s'. Details:\n%s" % (csvfile, model_name, messages))
+
 
 @step(u'I back up the database to "{dump_directory}"')
 def impl(ctx, dump_directory):


### PR DESCRIPTION
So the scenario fails if the file could not be imported.
By contract, Model.load() returns False in the key 'ids' when it could not load
a file with the reasons in the key 'messages'.

Closes #19
