### PR TITLE
make res.users.cvs loading faster

### DIFF
--- a/features/steps/tools.py
+++ b/features/steps/tools.py
@@ -53,7 +53,10 @@ def impl(ctx, model_name, csvfile, sep=","):
     head = data.next()
     # generator does not work
     values = [x for x in data]
-    result = model(model_name).load(head, values, ctx.oe_context)
+    context = ctx.oe_context
+    if model_name == 'res.users':
+        context = dict(context or {}, no_reset_password=True)
+    result = model(model_name).load(head, values, context)
     if not result['ids']:
         messages = '\n'.join('- %s' % msg for msg in result['messages'])
         raise Exception("Failed to load file '%s' "


### PR DESCRIPTION
if loaded model is `res.users`, we set `no_reset_password=True` in context to avoid sending mails during data load.