### PR TITLE
Always read admin_login_password from config file to be able to creat…

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -34,11 +34,14 @@ def before_all(ctx):
     ctx._output_write = _output_write
     ctx._is_context = True
     ctx.client = erppeek.Client(server, verbose=ctx.config.verbose)
-    ctx.conf = {'server': server,
-                'admin_passwd': server.tools.config['admin_passwd'],
-                'db_name': database,
-                'openerp_config': server.tools.config,
-                }
+    ctx.conf = {
+        'server': server,
+        'admin_passwd': server.tools.config['admin_passwd'],
+        'admin_login_password': server.tools.config.get(
+            'admin_login_password', 'admin'),
+        'db_name': database,
+        'openerp_config': server.tools.config,
+        }
 
 
 def before_feature(ctx, feature):
@@ -54,15 +57,13 @@ def before_scenario(ctx, scenario):
     # this allow to do database creation and sql requests
     # before trying to login in Odoo
     if not ctx.client.user and 'no_login' not in scenario.tags:
-        server = ctx.conf['server']
-        database = ctx.conf['db_name']
-        config = server.tools.config
         # We try to manage default login
         # even if there is a sentence to log a given user
         # Just add options.admin_login_password in your buildout to log from
         # config
-        admin_login_password = config.get('admin_login_password', 'admin')
-        ctx.client.login('admin', admin_login_password, database=database)
+        database = ctx.conf['db_name']
+        user_password = ctx.conf['admin_login_password']
+        ctx.client.login('admin', user_password, database=database)
 
 
 def before_step(ctx, step):

--- a/features/steps/database_mgmt.py
+++ b/features/steps/database_mgmt.py
@@ -29,9 +29,11 @@ def impl(ctx, user, password):
 
 
 def _create_database(ctx, admin_passwd, db_name, demo=False,
-                     raise_if_exists=True):
+                     user_password='admin', raise_if_exists=True):
     try:
-        ctx.client.create_database(admin_passwd, db_name, demo=demo)
+        ctx.client.create_database(
+                admin_passwd, db_name, demo=demo,
+                user_password=user_password)
     except openerp.service.db.DatabaseExists:
         if raise_if_exists:
             raise
@@ -95,10 +97,12 @@ def impl(ctx, find_or):
     """
     db_name = ctx.conf.get('db_name')
     admin_passwd = ctx.conf.get('admin_passwd') # empty for unix sockets
+    admin_login_password = ctx.conf.get('admin_login_password')
     assert db_name
     demo = False
     if not ctx.conf['openerp_config'].get('without_demo'):
         demo = True
     raise_if_exists = find_or.strip() != 'find or'
     _create_database(ctx, admin_passwd, db_name, demo=demo,
+                     user_password=admin_login_password,
                      raise_if_exists=raise_if_exists)


### PR DESCRIPTION
…e database and set admin login password

It also fix the use of Create db from config file as when using this phrase it was creating a database with admin login password = 'admin'. Thus launching scenarii was working in the first call, but then if you launched some additional scenarii in a second call it was trying to log in with password from config file. Leading to fail to log in as passwords mismatch. 