### PR TITLE
Fix unicode handling of errors

### DIFF
--- a/features/support/behave_better.py
+++ b/features/support/behave_better.py
@@ -118,7 +118,7 @@ class PrettyFormatter(formatter.pretty.PrettyFormatter):
                         except UnicodeDecodeError:
                             msg = msg.decode('utf-8', errors='replace')
             indented = indent(msg, u'      ')
-            self.stream.write(indented.encode('utf-8', errors='replace'))
+            self.stream.write(indented)
             self.stream.write('\n\n')
         self.stream.flush()
 


### PR DESCRIPTION
behave's stream expect to receive an unicode string, not a bytes string.

When it receive a byte string, we get an error such as the following,
which has the notably unpleasant consequence of hiding the real error.

```
Traceback (most recent call last):
  File "/usr/local/bin/behave", line 9, in <module>
    load_entry_point('behave==1.2.4', 'console_scripts', 'behave')()
  File "/usr/local/lib/python2.7/dist-packages/behave/__main__.py", line 111, in main
    failed = runner.run()
  File "/usr/local/lib/python2.7/dist-packages/behave/runner.py", line 659, in run
    return self.run_with_paths()
  File "/usr/local/lib/python2.7/dist-packages/behave/runner.py", line 680, in run_with_paths
    return self.run_model()
  File "/usr/local/lib/python2.7/dist-packages/behave/runner.py", line 481, in run_model
    failed = feature.run(self)
  File "/usr/local/lib/python2.7/dist-packages/behave/model.py", line 461, in run
    failed = scenario.run(runner)
  File "/usr/local/lib/python2.7/dist-packages/behave/model.py", line 784, in run
    if not step.run(runner):
  File "/usr/local/lib/python2.7/dist-packages/behave/model.py", line 1218, in run
    formatter.result(self)
  File "/usr/local/lib/python2.7/dist-packages/behave/formatter/pretty.py", line 160, in result
    self.stream.write(indent(result.error_message.strip(), u'      '))
  File "/usr/local/lib/python2.7/dist-packages/behave/textutil.py", line 29, in indent
    return newline.join([prefix + unicode(line) for line in lines])
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 14: ordinal not in range(128)
```